### PR TITLE
Fix Widgets width in call.

### DIFF
--- a/parambokeh/__init__.py
+++ b/parambokeh/__init__.py
@@ -122,7 +122,7 @@ class Widgets(param.ParameterizedFunction):
 
         widgets, views = self.widgets()
         plots = views + plots
-        container = widgetbox(widgets, width=self.width)
+        container = widgetbox(widgets, width=self.p.width)
         if plots:
             view_box = column(plots)
             layout = self.p.view_position


### PR DESCRIPTION
I.e. allow Widgets(..., width=x) to work.

I just happened to notice this; I don't actually need it. Seems to work when I try it.