### PR TITLE
Add basic doc/notebook testing + CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-# TODO: reduce duplication with yaml refs
-
 language: generic
 
 os:
@@ -14,8 +12,7 @@ env:
 stages:
   - test
   - name: deploy
-
-#if: branch = master
+    if: branch = master
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,9 @@ script:
 - python doc/test_notebooks.py
 
 stages:
-  - name: deploy
-    if: branch = master
+  - deploy
+#  - name: deploy
+#    if: branch = master
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ env:
   global:
     secure: qDzvmjcR6eLAmHx0ziN3Y5M8h65+OM+eBNERQsC3WSkeaD45rEE6a8w59dBdUzZBTLKO2RP8pKlgzxBZGOBlnLbTyN4RD/q2dA+gm5c0SDWWT4kVCiogJVsrzyRHVgMDmqDu56HPbQzhsW+5Qh2JKjVkkI7GwvGZRFB9WKQC8yjW/RfLvQ7bzX6jXbaHDYg9dywjI5u7da7HZKXyt/6nhebdaI19RdQHuESUqTADFEgdCKdzrNC+NqbJ8SUnNBBmkb1ZqoQ3/p1/Z/+uDi/2ThozE7Lz6gl8HtxVRnBiwNCDvZRE8uTB79+FlW0FJCVZ7qGO8jVWlVqy+WEEFh/6s9RP2PLd73CmItfF7BzSdxdurOYfnizboqCideSasDQK7XdeDiX4fPrgqbeesn8+XJ9vhxRAmpsNdZIU+2pivgviJwUZUwKwgzt3hf23ld9GpJg60wCfQRT8hiZc3/XsUPrzDjci7hwrRESqobPcuWk6xsFPTvJsTeOSLejP1wDOGAhufLTQIys26BSwHiaj6aI4RPK3Y4sy644m4IOfVvi3d+YfyN2Q5NO7QIwk5PjQBUEdwcIi3lAk2eAIjJamlDYFCRrnwuEoFinuFlUjtqpkuVTLgonTbk9KkIYnXeP3wYERrt4uOJtxDRCojBC0FI5rDbkhC3wP8Wef4EToQ+s=
 
-matrix:
-  include:
-    - env: PYTHON_VERSION="3.6"
-    - env: PYTHON_VERSION="2.7"
+#matrix:
+#  include:
+#    - env: PYTHON_VERSION="3.6"
+#    - env: PYTHON_VERSION="2.7"
 
 stages:
   - test
@@ -25,9 +25,38 @@ stages:
 jobs:
   include:
     - stage: test
-#      env:
-#      - PYTHON_VERSION="2.7"
-#      - PYTHON_VERSION="3.6"
+      env: PYTHON_VERSION="2.7"
+      install:
+      ##
+      - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+          wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+        else
+          wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+        fi
+      - bash miniconda.sh -b -p $HOME/miniconda
+      - export PATH="$HOME/miniconda/bin:$PATH"
+      - conda config --set always_yes yes --set changeps1 no
+      - conda update conda
+      ##
+      - conda create -n test-environment python=$PYTHON_VERSION
+      - source activate test-environment
+      - conda install param
+      - conda install -c bokeh "bokeh==0.12.9"
+      # dependencies for testing
+      - conda install -c conda-forge "holoviews>=1.8.4"
+      - conda install pandas notebook flake8 pyparsing
+      - python setup.py develop --no-deps
+      - conda env export
+      - conda list
+      script:
+        - flake8 --ignore E,W parambokeh
+        - python doc/test_notebooks.py lint
+        - python doc/test_notebooks.py
+
+    ##############
+
+    - stage: test
+      env: PYTHON_VERSION="3.6"
       install:
       ##
       - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ stages:
 jobs:
   include:
     - stage: test
+      env:
+      - PYTHON_VERSION="2.7"
+      - PYTHON_VERSION="3.6"
       install:
       ##
       - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ stages:
 
 jobs:
   include:
-    - &test
-      stage: testpy27
+    - &tests
+      stage: test
       env: PYTHON_VERSION="2.7"
       install:
       - source ./etc/travis-miniconda.sh
@@ -39,8 +39,8 @@ jobs:
         - python doc/test_notebooks.py lint
         - python doc/test_notebooks.py
 
-    - <<: *test
-      stage: testpy36
+    - <<: *tests
+      stage: test
       env: PYTHON_VERSION="3.6"
 
     - stage: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
       - conda install param
       - conda install -c bokeh "bokeh==0.12.9"
       # dependencies for testing
-      - conda install pandas notebook flake8
+      - conda install pandas holoviews notebook flake8
       - python setup.py develop --no-deps
       - conda env export
       - conda list

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ script:
 - python doc/test_notebooks.py
 
 stages:
+  - test
   - deploy
 #  - name: deploy
 #    if: branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
 stages:
   - test
   - name: deploy
-    #if: branch = master
+    if: branch = master
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+language: generic
+
+os:
+  - linux
+
+sudo: false
+
+env:
+  global:
+    secure: qDzvmjcR6eLAmHx0ziN3Y5M8h65+OM+eBNERQsC3WSkeaD45rEE6a8w59dBdUzZBTLKO2RP8pKlgzxBZGOBlnLbTyN4RD/q2dA+gm5c0SDWWT4kVCiogJVsrzyRHVgMDmqDu56HPbQzhsW+5Qh2JKjVkkI7GwvGZRFB9WKQC8yjW/RfLvQ7bzX6jXbaHDYg9dywjI5u7da7HZKXyt/6nhebdaI19RdQHuESUqTADFEgdCKdzrNC+NqbJ8SUnNBBmkb1ZqoQ3/p1/Z/+uDi/2ThozE7Lz6gl8HtxVRnBiwNCDvZRE8uTB79+FlW0FJCVZ7qGO8jVWlVqy+WEEFh/6s9RP2PLd73CmItfF7BzSdxdurOYfnizboqCideSasDQK7XdeDiX4fPrgqbeesn8+XJ9vhxRAmpsNdZIU+2pivgviJwUZUwKwgzt3hf23ld9GpJg60wCfQRT8hiZc3/XsUPrzDjci7hwrRESqobPcuWk6xsFPTvJsTeOSLejP1wDOGAhufLTQIys26BSwHiaj6aI4RPK3Y4sy644m4IOfVvi3d+YfyN2Q5NO7QIwk5PjQBUEdwcIi3lAk2eAIjJamlDYFCRrnwuEoFinuFlUjtqpkuVTLgonTbk9KkIYnXeP3wYERrt4uOJtxDRCojBC0FI5rDbkhC3wP8Wef4EToQ+s=
+  matrix:
+    # TODO: add 2.7
+    - PYTHON_VERSION="3.6"
+
+install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi  
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update conda
+  # for building and uploading packages 
+  - conda install conda-build=3.0.25
+  - conda install anaconda-client
+
+  # Install dependencies
+  - conda create -n test-environment python=$PYTHON_VERSION
+  - source activate test-environment
+  - conda install param
+  - conda install -c bokeh "bokeh>=0.12.10"
+  # for testing
+  - conda install notebook flake8
+  - python setup.py develop --no-deps
+  - conda env export
+  - conda list
+
+script:
+  - flake8 --ignore E,W parambokeh
+  - python doc/test_notebooks.py lint
+  - python doc/test_notebooks.py
+  - conda build conda.recipe
+  - anaconda -t $CONDA_UPLOAD_TOKEN upload --force -u cball $HOME/miniconda/conda-bld/noarch/parambokeh*.tar.bz2

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,11 @@ sudo: false
 env:
   global:
     secure: qDzvmjcR6eLAmHx0ziN3Y5M8h65+OM+eBNERQsC3WSkeaD45rEE6a8w59dBdUzZBTLKO2RP8pKlgzxBZGOBlnLbTyN4RD/q2dA+gm5c0SDWWT4kVCiogJVsrzyRHVgMDmqDu56HPbQzhsW+5Qh2JKjVkkI7GwvGZRFB9WKQC8yjW/RfLvQ7bzX6jXbaHDYg9dywjI5u7da7HZKXyt/6nhebdaI19RdQHuESUqTADFEgdCKdzrNC+NqbJ8SUnNBBmkb1ZqoQ3/p1/Z/+uDi/2ThozE7Lz6gl8HtxVRnBiwNCDvZRE8uTB79+FlW0FJCVZ7qGO8jVWlVqy+WEEFh/6s9RP2PLd73CmItfF7BzSdxdurOYfnizboqCideSasDQK7XdeDiX4fPrgqbeesn8+XJ9vhxRAmpsNdZIU+2pivgviJwUZUwKwgzt3hf23ld9GpJg60wCfQRT8hiZc3/XsUPrzDjci7hwrRESqobPcuWk6xsFPTvJsTeOSLejP1wDOGAhufLTQIys26BSwHiaj6aI4RPK3Y4sy644m4IOfVvi3d+YfyN2Q5NO7QIwk5PjQBUEdwcIi3lAk2eAIjJamlDYFCRrnwuEoFinuFlUjtqpkuVTLgonTbk9KkIYnXeP3wYERrt4uOJtxDRCojBC0FI5rDbkhC3wP8Wef4EToQ+s=
-  matrix:
-    - PYTHON_VERSION="3.6"
-    - PYTHON_VERSION="2.7"
+
+matrix:
+  include:
+    - env: PYTHON_VERSION="3.6"
+    - env: PYTHON_VERSION="2.7"
 
 stages:
   - test
@@ -23,9 +25,9 @@ stages:
 jobs:
   include:
     - stage: test
-      env:
-      - PYTHON_VERSION="2.7"
-      - PYTHON_VERSION="3.6"
+#      env:
+#      - PYTHON_VERSION="2.7"
+#      - PYTHON_VERSION="3.6"
       install:
       ##
       - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ jobs:
     - stage: test
       env:
       - PYTHON_VERSION=3.6
+      - PYTHON_VERSION=2.7
       install:
       ##
       - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
@@ -39,7 +40,8 @@ jobs:
       - conda install param
       - conda install -c bokeh "bokeh==0.12.9"
       # dependencies for testing
-      - conda install pandas holoviews notebook flake8 pyparsing
+      - conda install -c conda-forge "holoviews>=1.8.4"
+      - conda install pandas notebook flake8 pyparsing
       - python setup.py develop --no-deps
       - conda env export
       - conda list

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+# TODO: reduce duplication with yaml refs
+
 language: generic
 
 os:
@@ -8,38 +10,65 @@ sudo: false
 env:
   global:
     secure: qDzvmjcR6eLAmHx0ziN3Y5M8h65+OM+eBNERQsC3WSkeaD45rEE6a8w59dBdUzZBTLKO2RP8pKlgzxBZGOBlnLbTyN4RD/q2dA+gm5c0SDWWT4kVCiogJVsrzyRHVgMDmqDu56HPbQzhsW+5Qh2JKjVkkI7GwvGZRFB9WKQC8yjW/RfLvQ7bzX6jXbaHDYg9dywjI5u7da7HZKXyt/6nhebdaI19RdQHuESUqTADFEgdCKdzrNC+NqbJ8SUnNBBmkb1ZqoQ3/p1/Z/+uDi/2ThozE7Lz6gl8HtxVRnBiwNCDvZRE8uTB79+FlW0FJCVZ7qGO8jVWlVqy+WEEFh/6s9RP2PLd73CmItfF7BzSdxdurOYfnizboqCideSasDQK7XdeDiX4fPrgqbeesn8+XJ9vhxRAmpsNdZIU+2pivgviJwUZUwKwgzt3hf23ld9GpJg60wCfQRT8hiZc3/XsUPrzDjci7hwrRESqobPcuWk6xsFPTvJsTeOSLejP1wDOGAhufLTQIys26BSwHiaj6aI4RPK3Y4sy644m4IOfVvi3d+YfyN2Q5NO7QIwk5PjQBUEdwcIi3lAk2eAIjJamlDYFCRrnwuEoFinuFlUjtqpkuVTLgonTbk9KkIYnXeP3wYERrt4uOJtxDRCojBC0FI5rDbkhC3wP8Wef4EToQ+s=
-  matrix:
-    # TODO: add 2.7
-    - PYTHON_VERSION="3.6"
 
-install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi  
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update conda
-  # for building and uploading packages 
-  - conda install conda-build=3.0.25
-  - conda install anaconda-client
 
-  # Install dependencies
-  - conda create -n test-environment python=$PYTHON_VERSION
-  - source activate test-environment
-  - conda install param
-  - conda install -c bokeh "bokeh>=0.12.10"
-  # for testing
-  - conda install notebook flake8
-  - python setup.py develop --no-deps
-  - conda env export
-  - conda list
+stages:
+  - test
+  - deploy
 
-script:
-  - flake8 --ignore E,W parambokeh
-  - python doc/test_notebooks.py lint
-  - python doc/test_notebooks.py
-  - conda build conda.recipe
-  - anaconda -t $CONDA_UPLOAD_TOKEN upload --force -u cball $HOME/miniconda/conda-bld/noarch/parambokeh*.tar.bz2
+#  - name: deploy
+#    if: branch = master
+
+jobs:
+  include:
+    - stage: test
+      env:
+      - PYTHON_VERSION=3.6
+
+      install:
+      - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+          wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+        else
+          wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+        fi
+      - bash miniconda.sh -b -p $HOME/miniconda
+      - export PATH="$HOME/miniconda/bin:$PATH"
+      - conda config --set always_yes yes --set changeps1 no
+      - conda update conda
+
+      # Install dependencies
+      - conda create -n test-environment python=$PYTHON_VERSION
+      - source activate test-environment
+      - conda install param
+      - conda install -c bokeh "bokeh>=0.12.10"
+      # for testing
+      - conda install pandas notebook flake8
+      - python setup.py develop --no-deps
+      - conda env export
+      - conda list
+      ##############
+
+      script:
+        - flake8 --ignore E,W parambokeh
+        - python doc/test_notebooks.py lint
+        - python doc/test_notebooks.py
+
+    - stage: deploy
+      install:
+        - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+            wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+          else
+            wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+          fi
+        - bash miniconda.sh -b -p $HOME/miniconda
+        - export PATH="$HOME/miniconda/bin:$PATH"
+        - conda config --set always_yes yes --set changeps1 no
+        - conda update conda
+
+        # for building and uploading packages
+        - conda install conda-build=3.0.25
+        - conda install anaconda-client
+      script:
+        - conda build conda.recipe
+        - anaconda -t $CONDA_UPLOAD_TOKEN upload --force -u cball $HOME/miniconda/conda-bld/noarch/parambokeh*.tar.bz2
+      

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ env:
 stages:
   - test
   - name: deploy
-    if: branch = master
+
+#if: branch = master
 
 jobs:
   include:
@@ -52,7 +53,7 @@ jobs:
     ##############
 
     - stage: deploy
-      env: PYTHON_VERSION=3.6
+      env: PYTHON_VERSION="3.6"
       install:
       ##
       - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,44 +11,49 @@ env:
   global:
     secure: qDzvmjcR6eLAmHx0ziN3Y5M8h65+OM+eBNERQsC3WSkeaD45rEE6a8w59dBdUzZBTLKO2RP8pKlgzxBZGOBlnLbTyN4RD/q2dA+gm5c0SDWWT4kVCiogJVsrzyRHVgMDmqDu56HPbQzhsW+5Qh2JKjVkkI7GwvGZRFB9WKQC8yjW/RfLvQ7bzX6jXbaHDYg9dywjI5u7da7HZKXyt/6nhebdaI19RdQHuESUqTADFEgdCKdzrNC+NqbJ8SUnNBBmkb1ZqoQ3/p1/Z/+uDi/2ThozE7Lz6gl8HtxVRnBiwNCDvZRE8uTB79+FlW0FJCVZ7qGO8jVWlVqy+WEEFh/6s9RP2PLd73CmItfF7BzSdxdurOYfnizboqCideSasDQK7XdeDiX4fPrgqbeesn8+XJ9vhxRAmpsNdZIU+2pivgviJwUZUwKwgzt3hf23ld9GpJg60wCfQRT8hiZc3/XsUPrzDjci7hwrRESqobPcuWk6xsFPTvJsTeOSLejP1wDOGAhufLTQIys26BSwHiaj6aI4RPK3Y4sy644m4IOfVvi3d+YfyN2Q5NO7QIwk5PjQBUEdwcIi3lAk2eAIjJamlDYFCRrnwuEoFinuFlUjtqpkuVTLgonTbk9KkIYnXeP3wYERrt4uOJtxDRCojBC0FI5rDbkhC3wP8Wef4EToQ+s=
   matrix:
-    - PYTHON_VERSION="2.7"
     - PYTHON_VERSION="3.6"
-
-
-install:
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
-  else
-    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-  fi
-- bash miniconda.sh -b -p $HOME/miniconda
-- export PATH="$HOME/miniconda/bin:$PATH"
-- conda config --set always_yes yes --set changeps1 no
-- conda update conda
-- conda create -n test-environment python=$PYTHON_VERSION
-- source activate test-environment
-- conda install param
-- conda install -c bokeh "bokeh==0.12.9"
-# dependencies for testing
-- conda install -c conda-forge "holoviews>=1.8.4"
-- conda install pandas notebook flake8 pyparsing
-- python setup.py develop --no-deps
-- conda env export
-- conda list
-
-script:
-- flake8 --ignore E,W parambokeh
-- python doc/test_notebooks.py lint
-- python doc/test_notebooks.py
+    - PYTHON_VERSION="2.7"
 
 stages:
   - test
-  - deploy
-#  - name: deploy
-#    if: branch = master
+  - name: deploy
+    #if: branch = master
 
 jobs:
   include:
+    - stage: test
+      env:
+      - PYTHON_VERSION=3.6
+      - PYTHON_VERSION=2.7
+      install:
+      ##
+      - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+          wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+        else
+          wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+        fi
+      - bash miniconda.sh -b -p $HOME/miniconda
+      - export PATH="$HOME/miniconda/bin:$PATH"
+      - conda config --set always_yes yes --set changeps1 no
+      - conda update conda
+      ##
+      - conda create -n test-environment python=$PYTHON_VERSION
+      - source activate test-environment
+      - conda install param
+      - conda install -c bokeh "bokeh==0.12.9"
+      # dependencies for testing
+      - conda install -c conda-forge "holoviews>=1.8.4"
+      - conda install pandas notebook flake8 pyparsing
+      - python setup.py develop --no-deps
+      - conda env export
+      - conda list
+      script:
+        - flake8 --ignore E,W parambokeh
+        - python doc/test_notebooks.py lint
+        - python doc/test_notebooks.py
+
+    ##############
+
     - stage: deploy
       env: PYTHON_VERSION=3.6
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,6 @@ env:
   global:
     secure: qDzvmjcR6eLAmHx0ziN3Y5M8h65+OM+eBNERQsC3WSkeaD45rEE6a8w59dBdUzZBTLKO2RP8pKlgzxBZGOBlnLbTyN4RD/q2dA+gm5c0SDWWT4kVCiogJVsrzyRHVgMDmqDu56HPbQzhsW+5Qh2JKjVkkI7GwvGZRFB9WKQC8yjW/RfLvQ7bzX6jXbaHDYg9dywjI5u7da7HZKXyt/6nhebdaI19RdQHuESUqTADFEgdCKdzrNC+NqbJ8SUnNBBmkb1ZqoQ3/p1/Z/+uDi/2ThozE7Lz6gl8HtxVRnBiwNCDvZRE8uTB79+FlW0FJCVZ7qGO8jVWlVqy+WEEFh/6s9RP2PLd73CmItfF7BzSdxdurOYfnizboqCideSasDQK7XdeDiX4fPrgqbeesn8+XJ9vhxRAmpsNdZIU+2pivgviJwUZUwKwgzt3hf23ld9GpJg60wCfQRT8hiZc3/XsUPrzDjci7hwrRESqobPcuWk6xsFPTvJsTeOSLejP1wDOGAhufLTQIys26BSwHiaj6aI4RPK3Y4sy644m4IOfVvi3d+YfyN2Q5NO7QIwk5PjQBUEdwcIi3lAk2eAIjJamlDYFCRrnwuEoFinuFlUjtqpkuVTLgonTbk9KkIYnXeP3wYERrt4uOJtxDRCojBC0FI5rDbkhC3wP8Wef4EToQ+s=
 
-#matrix:
-#  include:
-#    - env: PYTHON_VERSION="3.6"
-#    - env: PYTHON_VERSION="2.7"
-
 stages:
   - test
   - name: deploy
@@ -24,20 +19,11 @@ stages:
 
 jobs:
   include:
-    - stage: test
+    - &tests
+      stage: test
       env: PYTHON_VERSION="2.7"
       install:
-      ##
-      - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-          wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
-        else
-          wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-        fi
-      - bash miniconda.sh -b -p $HOME/miniconda
-      - export PATH="$HOME/miniconda/bin:$PATH"
-      - conda config --set always_yes yes --set changeps1 no
-      - conda update conda
-      ##
+      - etc/travis-miniconda.sh
       - conda create -n test-environment python=$PYTHON_VERSION
       - source activate test-environment
       - conda install param
@@ -55,51 +41,13 @@ jobs:
 
     ##############
 
-    - stage: test
+    - <<: *tests
       env: PYTHON_VERSION="3.6"
-      install:
-      ##
-      - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-          wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
-        else
-          wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-        fi
-      - bash miniconda.sh -b -p $HOME/miniconda
-      - export PATH="$HOME/miniconda/bin:$PATH"
-      - conda config --set always_yes yes --set changeps1 no
-      - conda update conda
-      ##
-      - conda create -n test-environment python=$PYTHON_VERSION
-      - source activate test-environment
-      - conda install param
-      - conda install -c bokeh "bokeh==0.12.9"
-      # dependencies for testing
-      - conda install -c conda-forge "holoviews>=1.8.4"
-      - conda install pandas notebook flake8 pyparsing
-      - python setup.py develop --no-deps
-      - conda env export
-      - conda list
-      script:
-        - flake8 --ignore E,W parambokeh
-        - python doc/test_notebooks.py lint
-        - python doc/test_notebooks.py
-
-    ##############
 
     - stage: deploy
       env: PYTHON_VERSION="3.6"
       install:
-      ##
-      - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-          wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
-        else
-          wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-        fi
-      - bash miniconda.sh -b -p $HOME/miniconda
-      - export PATH="$HOME/miniconda/bin:$PATH"
-      - conda config --set always_yes yes --set changeps1 no
-      - conda update conda
-      ##
+      - etc/travis-miniconda.sh
       # for building and uploading packages
       - conda install conda-build=3.0.25
       - conda install anaconda-client

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,6 @@ stages:
 jobs:
   include:
     - stage: test
-      env:
-      - PYTHON_VERSION=3.6
-      - PYTHON_VERSION=2.7
       install:
       ##
       - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
       - conda install param
       - conda install -c bokeh "bokeh==0.12.9"
       # dependencies for testing
-      - conda install pandas holoviews notebook flake8
+      - conda install pandas holoviews notebook flake8 pyparsing
       - python setup.py develop --no-deps
       - conda env export
       - conda list

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,49 +10,45 @@ sudo: false
 env:
   global:
     secure: qDzvmjcR6eLAmHx0ziN3Y5M8h65+OM+eBNERQsC3WSkeaD45rEE6a8w59dBdUzZBTLKO2RP8pKlgzxBZGOBlnLbTyN4RD/q2dA+gm5c0SDWWT4kVCiogJVsrzyRHVgMDmqDu56HPbQzhsW+5Qh2JKjVkkI7GwvGZRFB9WKQC8yjW/RfLvQ7bzX6jXbaHDYg9dywjI5u7da7HZKXyt/6nhebdaI19RdQHuESUqTADFEgdCKdzrNC+NqbJ8SUnNBBmkb1ZqoQ3/p1/Z/+uDi/2ThozE7Lz6gl8HtxVRnBiwNCDvZRE8uTB79+FlW0FJCVZ7qGO8jVWlVqy+WEEFh/6s9RP2PLd73CmItfF7BzSdxdurOYfnizboqCideSasDQK7XdeDiX4fPrgqbeesn8+XJ9vhxRAmpsNdZIU+2pivgviJwUZUwKwgzt3hf23ld9GpJg60wCfQRT8hiZc3/XsUPrzDjci7hwrRESqobPcuWk6xsFPTvJsTeOSLejP1wDOGAhufLTQIys26BSwHiaj6aI4RPK3Y4sy644m4IOfVvi3d+YfyN2Q5NO7QIwk5PjQBUEdwcIi3lAk2eAIjJamlDYFCRrnwuEoFinuFlUjtqpkuVTLgonTbk9KkIYnXeP3wYERrt4uOJtxDRCojBC0FI5rDbkhC3wP8Wef4EToQ+s=
+  matrix:
+    - PYTHON_VERSION="2.7"
+    - PYTHON_VERSION="3.6"
 
+
+install:
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+  else
+    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+  fi
+- bash miniconda.sh -b -p $HOME/miniconda
+- export PATH="$HOME/miniconda/bin:$PATH"
+- conda config --set always_yes yes --set changeps1 no
+- conda update conda
+- conda create -n test-environment python=$PYTHON_VERSION
+- source activate test-environment
+- conda install param
+- conda install -c bokeh "bokeh==0.12.9"
+# dependencies for testing
+- conda install -c conda-forge "holoviews>=1.8.4"
+- conda install pandas notebook flake8 pyparsing
+- python setup.py develop --no-deps
+- conda env export
+- conda list
+
+script:
+- flake8 --ignore E,W parambokeh
+- python doc/test_notebooks.py lint
+- python doc/test_notebooks.py
 
 stages:
-  - test
   - name: deploy
     if: branch = master
 
 jobs:
   include:
-    - stage: test
-      env:
-      - PYTHON_VERSION=3.6
-      - PYTHON_VERSION=2.7
-      install:
-      ##
-      - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-          wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
-        else
-          wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-        fi
-      - bash miniconda.sh -b -p $HOME/miniconda
-      - export PATH="$HOME/miniconda/bin:$PATH"
-      - conda config --set always_yes yes --set changeps1 no
-      - conda update conda
-      ##
-      - conda create -n test-environment python=$PYTHON_VERSION
-      - source activate test-environment
-      - conda install param
-      - conda install -c bokeh "bokeh==0.12.9"
-      # dependencies for testing
-      - conda install -c conda-forge "holoviews>=1.8.4"
-      - conda install pandas notebook flake8 pyparsing
-      - python setup.py develop --no-deps
-      - conda env export
-      - conda list
-      script:
-        - flake8 --ignore E,W parambokeh
-        - python doc/test_notebooks.py lint
-        - python doc/test_notebooks.py
-
-    ##############
-
     - stage: deploy
+      env: PYTHON_VERSION=3.6
       install:
       ##
       - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,11 @@ stages:
 
 jobs:
   include:
-    - &tests
-      stage: test
+    - &test
+      stage: testpy27
       env: PYTHON_VERSION="2.7"
       install:
-      - etc/travis-miniconda.sh
+      - source ./etc/travis-miniconda.sh
       - conda create -n test-environment python=$PYTHON_VERSION
       - source activate test-environment
       - conda install param
@@ -39,15 +39,14 @@ jobs:
         - python doc/test_notebooks.py lint
         - python doc/test_notebooks.py
 
-    ##############
-
-    - <<: *tests
+    - <<: *test
+      stage: testpy36
       env: PYTHON_VERSION="3.6"
 
     - stage: deploy
       env: PYTHON_VERSION="3.6"
       install:
-      - etc/travis-miniconda.sh
+      - source ./etc/travis-miniconda.sh
       # for building and uploading packages
       - conda install conda-build=3.0.25
       - conda install anaconda-client

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,8 @@ env:
 
 stages:
   - test
-  - deploy
-
-#  - name: deploy
-#    if: branch = master
+  - name: deploy
+    if: branch = master
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ jobs:
     - stage: test
       env:
       - PYTHON_VERSION=3.6
-
       install:
+      ##
       - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
           wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
         else
@@ -35,40 +35,39 @@ jobs:
       - export PATH="$HOME/miniconda/bin:$PATH"
       - conda config --set always_yes yes --set changeps1 no
       - conda update conda
-
-      # Install dependencies
+      ##
       - conda create -n test-environment python=$PYTHON_VERSION
       - source activate test-environment
       - conda install param
-      - conda install -c bokeh "bokeh>=0.12.10"
-      # for testing
+      - conda install -c bokeh "bokeh==0.12.9"
+      # dependencies for testing
       - conda install pandas notebook flake8
       - python setup.py develop --no-deps
       - conda env export
       - conda list
-      ##############
-
       script:
         - flake8 --ignore E,W parambokeh
         - python doc/test_notebooks.py lint
         - python doc/test_notebooks.py
 
+    ##############
+
     - stage: deploy
       install:
-        - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-            wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
-          else
-            wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-          fi
-        - bash miniconda.sh -b -p $HOME/miniconda
-        - export PATH="$HOME/miniconda/bin:$PATH"
-        - conda config --set always_yes yes --set changeps1 no
-        - conda update conda
-
-        # for building and uploading packages
-        - conda install conda-build=3.0.25
-        - conda install anaconda-client
+      ##
+      - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+          wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+        else
+          wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+        fi
+      - bash miniconda.sh -b -p $HOME/miniconda
+      - export PATH="$HOME/miniconda/bin:$PATH"
+      - conda config --set always_yes yes --set changeps1 no
+      - conda update conda
+      ##
+      # for building and uploading packages
+      - conda install conda-build=3.0.25
+      - conda install anaconda-client
       script:
-        - conda build conda.recipe
-        - anaconda -t $CONDA_UPLOAD_TOKEN upload --force -u cball $HOME/miniconda/conda-bld/noarch/parambokeh*.tar.bz2
-      
+      - conda build conda.recipe
+      - anaconda -t $CONDA_UPLOAD_TOKEN upload --force -u cball $HOME/miniconda/conda-bld/noarch/parambokeh*.tar.bz2

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-SRC_DIR=$RECIPE_DIR/..
-pushd $SRC_DIR
-
-$PYTHON setup.py --quiet install --single-version-externally-managed --record=record.txt
-
-popd

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -16,7 +16,7 @@ requirements:
   run:
     - python
     - param
-    - bokeh =0.12.9
+    - bokeh >=0.12.9,<0.12.10
 
 test:
   imports:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: parambokeh
-  version: {{ GIT_DESCRIBE_TAG }}
+  version: {{ environ['GIT_DESCRIBE_TAG'].lstrip('v') }}
 
 source:
   path: ..

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: {{ GIT_DESCRIBE_TAG }}
 
 source:
-  path: .
+  path: ..
 
 build:
   noarch: python

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,9 +1,14 @@
 package:
   name: parambokeh
-  version: 0.2.1
+  version: {{ GIT_DESCRIBE_TAG }}
 
 source:
   path: .
+
+build:
+  noarch: python
+  number: {{ GIT_DESCRIBE_NUMBER|int }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
   build:
@@ -11,7 +16,7 @@ requirements:
   run:
     - python
     - param
-    - bokeh
+    - bokeh >=0.12.10
 
 test:
   imports:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -16,7 +16,7 @@ requirements:
   run:
     - python
     - param
-    - bokeh >=0.12.10
+    - bokeh =0.12.9
 
 test:
   imports:

--- a/doc/ViewParameters.ipynb
+++ b/doc/ViewParameters.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "import param\n",
     "import parambokeh\n",
-    "from bokeh.io import show, output_notebook\n",
+    "from bokeh.io import output_notebook\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
@@ -82,7 +82,7 @@
     "        if not self.output or any(k in kwargs for k in ['color', 'element']):\n",
     "            self.output = hv.DynamicMap(self.view, streams=[self])\n",
     "        else:\n",
-    "            super(ImageExample, self).event(**kwargs)\n",
+    "            super(CurveExample, self).event(**kwargs)\n",
     "\n",
     "example = CurveExample(name='HoloViews Example')\n",
     "parambokeh.Widgets(example, callback=example.event, push=False,\n",

--- a/doc/index.ipynb
+++ b/doc/index.ipynb
@@ -79,7 +79,7 @@
    "outputs": [],
    "source": [
     "import parambokeh\n",
-    "from bokeh.io import output_notebook, show\n",
+    "from bokeh.io import output_notebook\n",
     "output_notebook()"
    ]
   },

--- a/doc/test_notebooks.py
+++ b/doc/test_notebooks.py
@@ -24,7 +24,7 @@ import pprint
 
 nbdir = "doc"
 
-run_skip = [] # (gave up waiting on my laptop)
+run_skip = ["doc/ViewParameters.ipynb"]
 
 run_allow_error = []
 

--- a/doc/test_notebooks.py
+++ b/doc/test_notebooks.py
@@ -1,0 +1,90 @@
+# Temporary script to allow checking notebooks run without errors, or
+# to approximately lint check notebooks.
+#
+# Note: lint checking will not yet work on windows unless sed is
+# present or we replace sed with python equivalent.
+#
+# Run all notebooks & render to html:
+#  python examples/test_notebooks.py
+#
+# Approximately lint check all notebooks:
+#  python examples/test_notebooks.py lint
+
+from __future__ import print_function
+
+import sys
+import os
+import glob
+import pprint
+
+############################################################
+# Set nbdir, run_skip, and run_allow_error for your project.
+# You may need to increase run_cell_timeout if you have
+# notebook cells that take a long time to execute.
+
+nbdir = "doc"
+
+run_skip = [] # (gave up waiting on my laptop)
+
+run_allow_error = []
+
+run_cell_timeout = 360
+
+############################################################
+
+
+notebooks = sorted([x.replace(os.path.sep, "/") for x in glob.glob(nbdir + "/*.ipynb")])
+
+checked = []
+errored = []
+run_skipped = []
+
+if len(sys.argv) == 1:
+    do_what = "run"
+elif sys.argv[1] == "lint":
+    do_what = "lint"
+else:
+    raise
+
+if do_what == "run":
+    for nb in notebooks:
+        cmd = "jupyter nbconvert %s --execute --ExecutePreprocessor.kernel_name=python%s --ExecutePreprocessor.timeout=%s --to html" % (nb, sys.version_info[0], run_cell_timeout)
+        if nb in run_skip:
+            run_skipped.append(nb)
+            continue
+
+        if nb in run_allow_error:
+            cmd += " --allow-errors"
+        print(cmd)
+        r = os.system(cmd)
+        checked.append(nb)
+        if r != 0:
+            errored.append(nb)
+
+elif sys.argv[1] == 'lint':
+    for nb in notebooks:
+        cmd = """sed -e 's/%/#%/' {f} > {f}~ && jupyter nbconvert {f}~ --to python --PythonExporter.file_extension=.py~ && flake8 --ignore=E,W {p}""".format(f=nb, p=nb[0:-5] + 'py~')
+        print(cmd)
+        r = os.system(cmd)
+        checked.append(nb)
+        if r != 0:
+            errored.append(nb)
+else:
+    raise
+
+print("%s checked" % len(checked))
+if len(checked) > 0: pprint.pprint(checked)
+print()
+print("%s error(s)" % len(errored))
+if len(errored) > 0: pprint.pprint(errored)
+print()
+
+if do_what == 'run':
+    print("%s skipped" % len(run_skipped))
+    if len(run_skipped) > 0: pprint.pprint(run_skipped)
+    print()
+    if len(run_allow_error) > 0:
+        print("Note: the following notebooks were not checked for run errors:")
+        pprint.pprint(run_allow_error)
+
+sys.exit(len(errored))

--- a/doc/test_notebooks.py
+++ b/doc/test_notebooks.py
@@ -24,7 +24,7 @@ import pprint
 
 nbdir = "doc"
 
-run_skip = ["doc/ViewParameters.ipynb"]
+run_skip = []
 
 run_allow_error = []
 

--- a/etc/travis-miniconda.sh
+++ b/etc/travis-miniconda.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -ev
+
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+else
+  wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+fi
+bash miniconda.sh -b -p $HOME/miniconda
+export PATH="$HOME/miniconda/bin:$PATH"
+conda config --set always_yes yes --set changeps1 no
+conda update conda

--- a/etc/travis-miniconda.sh
+++ b/etc/travis-miniconda.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 set -ev
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/parambokeh/__init__.py
+++ b/parambokeh/__init__.py
@@ -214,7 +214,6 @@ class Widgets(param.ParameterizedFunction):
 
 
     def _update_trait(self, p_name, p_value, widget=None):
-        p_obj = self.parameterized.params(p_name)
         widget = self._widgets[p_name] if widget is None else widget
         if isinstance(p_value, tuple):
             p_value, size = p_value
@@ -338,7 +337,7 @@ class Widgets(param.ParameterizedFunction):
         ordered_params = [el[0] for group in sorted_groups for el in group]
 
         # Format name specially
-        name = ordered_params.pop(ordered_params.index('name'))
+        ordered_params.pop(ordered_params.index('name'))
         widgets = [Div(text='<b>{0}</b>'.format(self.parameterized.name))]
 
         def format_name(pname):

--- a/parambokeh/widgets.py
+++ b/parambokeh/widgets.py
@@ -1,10 +1,10 @@
 import param
 from param.parameterized import classlist
 
-from bokeh.layouts import widgetbox, row, column
+from bokeh.layouts import column
 from bokeh.models.widgets import (
-    Button, TextInput, Div, Slider, Bool, CheckboxGroup, Toggle,
-    DatePicker, MultiSelect, Select, PreText, RangeSlider
+    Button, TextInput, Div, Slider, Toggle,
+    DatePicker, MultiSelect, Select, RangeSlider
 )
 
 from .util import as_unicode


### PR DESCRIPTION
Includes:
  * If on master, conda package building if the tests pass (plus uploading to https://anaconda.org/cball/parambokeh)
  * noarch packages (bokeh's noarch, so any problems with noarch will happen for parambokeh anyway...)
  * Running doc notebooks
  * Some import/flake fixes
  * pin to bokeh 0.12.9

Anaconda.org will have packages that look like this:

<img width="1218" alt="screen shot 2017-10-22 at 4 22 49 am" src="https://user-images.githubusercontent.com/1929/31857882-e76a2eae-b6e0-11e7-8d91-7afe370609e0.png">

("34th commit since 0.2.1". Will only be uploaded from master. We could make the label anything. The hash is a conda build thing.)

Future work:
  * Pin bokeh to >=0.12.10
  * When you import from the conda package, you get a `__version__` of `0.2.1` but it should have git info in it like hash and commit count (will probably need to adjust setup.py or something).
  * test_notebooks script has been copied into several projects as a stop-gap measure; will do something about that. But I am in favor of having *something* right now, and replacing it later.
  * Ideally, would also make 'travis miniconda' script into some kind of travis recipe maintained by someone else...but I fear lots of this ci stuff I keep copying across projects will just have to live in ioam-builder or some project on pypi or something (e.g. some parts really need to work across platforms, including windows). I.e. this is probably related to the point above.

Questions for Philipp:
* where to upload package and with what label?
* why pyparsing still required even after conda install hv? (optional dep of hv?)