### PR TITLE
Git hash into conda package name.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 stages:
   - test
   - name: deploy
-    if: branch = master
+    if: branch = master AND type != pull_request  
 
 jobs:
   include:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,13 +1,12 @@
 package:
   name: parambokeh
-  version: {{ environ['GIT_DESCRIBE_TAG'].lstrip('v') }}
+  version: {{ environ['GIT_DESCRIBE_TAG'].lstrip('v') }}.{{ GIT_BUILD_STR }}
 
 source:
   path: ..
 
 build:
   noarch: python
-  number: {{ GIT_DESCRIBE_NUMBER|int }}
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:


### PR DESCRIPTION
I copied what conda-build does for itself.

Looks like you get package names like this: 

`parambokeh-0.2.1.7_g9aa8bc6-pyh3a8a44e_0.tar.bz2`

`parambokeh-(git tag).(commits since)_(git sha)-(conda build hash)_buildnum`