### PR TITLE
Deploy website to alternative address for every commit to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 
 stages:
   - test
-  - docs  
+  - doc
   - name: anaconda_deploy
     if: branch = master AND type != pull_request
 
@@ -44,7 +44,7 @@ jobs:
     - <<: *tests
       env: PYTHON_VERSION="3.6"
 
-    - stage: docs
+    - stage: doc
       env: PYTHON_VERSION="3.6"
       install:
       # TODO: could (build and) use conda package; to be cleaned up
@@ -67,15 +67,20 @@ jobs:
       - touch ./_build/html/.nojekyll
       - nbsite_cleandisthtml.py ./_build/html take_a_chance
       deploy:
-        provider: pages
-        skip_cleanup: true
-        github_token: $GITHUB_TOKEN
-        local_dir: ./_build/html
-        on:
-          # TODO: depending on what we do for auto versioning/packaging,
-          # should make this deploy somewhere for PRs etc, and only to the
-          # main site on specific tag format.
-          tags: true
+        - provider: pages
+          skip_cleanup: true
+          github_token: $GITHUB_TOKEN
+          local_dir: ./_build/html
+          on:
+            # TODO: depending on what we do for auto versioning/packaging,
+            # should make this deploy somewhere for PRs etc, and only to the
+            # main site on specific tag format.
+            tags: true
+	- provider: pages
+          skip_cleanup: true
+	  github_token: $GITHUB_TOKEN
+	  local_dir: ./_build/html
+	  repo: ioam-docs/parambokeh-master
 
     - stage: anaconda_deploy
       env: PYTHON_VERSION="3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ jobs:
       - conda create -n test-environment python=$PYTHON_VERSION
       - source activate test-environment
       - conda install param
-      - conda install pandas      
+      - conda install pandas
       - conda install -c bokeh "bokeh>=0.12.10"
       - conda install -c ioam "holoviews>=1.9.0"
       - conda install -c conda-forge notebook ipython sphinx beautifulsoup4 graphviz selenium phantomjs
@@ -76,11 +76,11 @@ jobs:
             # should make this deploy somewhere for PRs etc, and only to the
             # main site on specific tag format.
             tags: true
-	- provider: pages
+        - provider: pages
           skip_cleanup: true
-	  github_token: $GITHUB_TOKEN
-	  local_dir: ./_build/html
-	  repo: ioam-docs/parambokeh-master
+          github_token: $GITHUB_TOKEN
+          local_dir: ./_build/html
+          repo: ioam-docs/parambokeh-master
 
     - stage: anaconda_deploy
       env: PYTHON_VERSION="3.6"
@@ -92,6 +92,3 @@ jobs:
       script:
       - conda build conda.recipe
       - anaconda -t $CONDA_UPLOAD_TOKEN upload --force -u cball $HOME/miniconda/conda-bld/noarch/parambokeh*.tar.bz2
-
-
-


### PR DESCRIPTION
Currently, will deploy to ioam-docs.github.io/parambokeh-master

Note 1: can't test this works without merging.

Note 2: eventually would be nice to have docs deployed somewhere for PRs, too, but this PR doesn't address that; plan to see how this works out for a bit first.
