### PR TITLE
Replace buttons with checkboxes for booleans

### DIFF
--- a/parambokeh/__init__.py
+++ b/parambokeh/__init__.py
@@ -10,7 +10,7 @@ import param
 from bokeh.document import Document
 from bokeh.io import push_notebook, curdoc
 from bokeh.layouts import row, column, widgetbox
-from bokeh.models.widgets import Div, Button, Toggle, TextInput
+from bokeh.models.widgets import Div, Button, CheckboxGroup, TextInput
 from bokeh.models import CustomJS
 
 try:
@@ -288,7 +288,7 @@ class Widgets(param.ParameterizedFunction):
 
         if hasattr(p_obj, 'callbacks'):
             p_obj.callbacks[id(self.parameterized)] = functools.partial(self._update_trait, p_name)
-        elif isinstance(w, Toggle):
+        elif isinstance(w, CheckboxGroup):
             if self.p.mode in ['server', 'raw']:
                 w.on_change('active', functools.partial(self.on_change, w, p_obj, p_name))
             else:

--- a/parambokeh/__init__.py
+++ b/parambokeh/__init__.py
@@ -214,6 +214,9 @@ class Widgets(param.ParameterizedFunction):
         if isinstance(p_obj, param.Range):
             new_values = tuple(new_values)
 
+        if isinstance(w, CheckboxGroup):
+            new_values = True if (len(new_values)>0 and new_values[0]==0) else False
+            
         # If no error during evaluation try to set parameter
         if not error:
             try:

--- a/parambokeh/widgets.py
+++ b/parambokeh/widgets.py
@@ -5,7 +5,7 @@ from param.parameterized import classlist
 
 from bokeh.layouts import column
 from bokeh.models.widgets import (
-    Button, TextInput, Div, Slider, Toggle,
+    Button, TextInput, Div, Slider, CheckboxGroup,
     DatePicker, MultiSelect, Select, RangeSlider
 )
 
@@ -24,10 +24,10 @@ def StaticText(*args, **kw):
                                                   value=as_unicode(kw.pop('value')))
     return Div(*args, **kw)
 
-def ToggleWidget(*args, **kw):
-    kw['active'] = kw.pop('value')
-    kw['label'] = kw.pop('title')
-    return Toggle(*args, **kw)
+def Checkbox(*args, **kw):
+    kw['active'] = [kw.pop('value')]
+    kw['labels'] = [kw.pop('title')]
+    return CheckboxGroup(*args, **kw)
 
 def ButtonWidget(*args, **kw):
     kw['label'] = kw.pop('title')
@@ -103,7 +103,7 @@ ptype2wtype = {
     param.Parameter:     TextWidget,
     param.Dict:          TextWidget,
     param.Selector:      Select,
-    param.Boolean:       ToggleWidget,
+    param.Boolean:       Checkbox,
     param.Number:        FloatSlider,
     param.Integer:       IntSlider,
     param.Range:         RangeWidget,

--- a/parambokeh/widgets.py
+++ b/parambokeh/widgets.py
@@ -25,7 +25,8 @@ def StaticText(*args, **kw):
     return Div(*args, **kw)
 
 def Checkbox(*args, **kw):
-    kw['active'] = [kw.pop('value')]
+    val = kw.pop('value')
+    kw['active'] = [0] if val else []
     kw['labels'] = [kw.pop('title')]
     return CheckboxGroup(*args, **kw)
 


### PR DESCRIPTION
Right now, Boolean parameters are rendered as buttons:

![image](https://user-images.githubusercontent.com/1695496/35460059-2a27ea02-02a8-11e8-8579-aa83e56d5b24.png)

This is confusing, because buttons are also used for actions, so it's not clear whether pushing the button will change the value or perform an action.  Plus the state of the boolean is difficult to determine; is an active button true or is it false?

This PR replaces buttons with the more standard and clearer checkboxes:

![image](https://user-images.githubusercontent.com/1695496/35460124-6d4af2b6-02a8-11e8-8c74-b0e112c9e20c.png)

The only slight problem is that it doesn't actually work; the checkbox doesn't reflect the state of the parameter, and changing the checkbox doesn't affect the value of the parameter.

@ceball and @philippjfr, do either of you know how to fix this PR so it actually does something useful?  I knew how to make things like this work on paramnb, but haven't figured out parambokeh yet. I would guess it's something to do with CheckBoxGroup using a list for its ``active`` keyword or ``labels`` instead of ``label``, but I'm not sure how to debug it from here.