### PR TITLE
Allow redrawing view parameters in notebook

### DIFF
--- a/parambokeh/__init__.py
+++ b/parambokeh/__init__.py
@@ -244,8 +244,6 @@ class Widgets(param.ParameterizedFunction):
             p_value, size = p_value
         if isinstance(widget, Div):
             widget.text = p_value
-        elif self.p.mode == 'notebook' and self.shown:
-            return
         else:
             if widget.children:
                 widget.children.remove(widget.children[0])


### PR DESCRIPTION
In recent versions of bokeh it's possible to add and remove models dynamically in the notebook so this lifts the original restriction on view parameters.