### PR TITLE
Declared pyviz_comms dependency

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -15,6 +15,7 @@ requirements:
   run:
     - python
     - param
+    - pyviz_comms
     - bokeh >=0.12.10
 
 test:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
     from distutils.core import setup
 
 setup_args = {}
-install_requires = ['param>=1.5.1', 'bokeh>=0.12.10']
+install_requires = ['param>=1.5.1', 'bokeh>=0.12.10', 'pyviz_comms']
 
 setup_args.update(dict(
     name='parambokeh',


### PR DESCRIPTION
Note that ``pyviz_comms`` currently on exists on the pyviz anaconda channel: it isn't on PYPI or on the defaults channel just yet.