### PR TITLE
Fixed show_labels parameter

### DIFF
--- a/parambokeh/__init__.py
+++ b/parambokeh/__init__.py
@@ -342,7 +342,9 @@ class Widgets(param.ParameterizedFunction):
 
         kw = dict(value=value)
 
-        if self.p.label_formatter is not None:
+        if self.p.show_labels is False:
+            kw['title'] = ''
+        elif self.p.label_formatter is not None:
             kw['title'] = self.p.label_formatter(p_name)
         else:
             kw['title'] = p_name
@@ -456,10 +458,7 @@ class Widgets(param.ParameterizedFunction):
             name = "" if issubclass(type(p),param.Action) else pname
             return Div(text=name)
 
-        if self.p.show_labels:
-            widgets += [self.widget(pname) for pname in ordered_params]
-        else:
-            widgets += [self.widget(pname) for pname in ordered_params]
+        widgets += [self.widget(pname) for pname in ordered_params]
 
         if self.p.button and not (self.p.callback is None and self.p.next_n==0):
             display_button = Button(label=self.p.button_text)


### PR DESCRIPTION
Fixes the ``show_labels`` parameter which wasn't doing anything (#10):

![image](https://user-images.githubusercontent.com/890576/40542656-e934f1ba-6018-11e8-9427-df4de0df2735.png)

I'm not yet sure this is the right fix as I am using an empty string as the label which means the vertical spacing is unchanged. If the labels are truly dropped the widgets should probably be more compressed vertically.
