### PR TITLE
WIP: demo of how to use index.ipynb with current nbsite

### DIFF
--- a/doc/_index.rst
+++ b/doc/_index.rst
@@ -1,0 +1,8 @@
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+
+   Introduction <self>
+   User Guide <user_guide/index>
+   FAQ
+   About <about>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,7 +1,3 @@
-*****
-index
-*****
-
 .. notebook:: parambokeh ../examples/index.ipynb
     :offset: 0
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,29 +1,8 @@
-**********
-ParamBokeh
-**********
+*****
+index
+*****
 
-**Generate bokeh widgets for parameterized objects**
+.. notebook:: parambokeh ../examples/index.ipynb
+    :offset: 0
 
-ParamBokeh is an `open-source
-<https://github.com/ioam/holoviews/blob/master/LICENSE.txt>`_ Python
-library that allows you to easily create GUIs from existing objects
-(in Jupyter notebooks, Bokeh apps, and potentially more)
-
-The `User Guide <user_guide>`_ shows the concepts involved with ParamBokeh
-and should help you get started using it as quickly as possible.
-
-Please feel free to report `issues
-<https://github.com/ioam/parambokeh/issues>`_ or `contribute code
-<https://help.github.com/articles/about-pull-requests>`_. You are also
-welcome to chat with the developers on `gitter
-<https://gitter.im/ioam/holoviews>`_.
-
-
-.. toctree::
-   :hidden:
-   :maxdepth: 2
-
-   Introduction <self>
-   User Guide <user_guide/index>
-   FAQ
-   About <about>
+.. include:: _index.rst

--- a/examples/index.ipynb
+++ b/examples/index.ipynb
@@ -22,22 +22,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/index.ipynb
+++ b/examples/index.ipynb
@@ -1,0 +1,45 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# ParamBokeh"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Generate bokeh widgets for parameterized objects**\n",
+    "\n",
+    "ParamBokeh is an [open-source](https://github.com/ioam/parambokeh/blob/master/LICENSE) Python library that allows you to easily create GUIs from existing objects (in Jupyter notebooks, Bokeh apps, and potentially more).\n",
+    "\n",
+    "The [User Guide](user_guide) shows the concepts involved with ParamBokeh and should help you get started using it as quickly as possible.\n",
+    "\n",
+    "Please feel free to report [issues](https://github.com/ioam/parambokeh/issues) or [contribute code](https://help.github.com/articles/about-pull-requests). You are also welcome to chat with the developers on [gitter](https://gitter.im/ioam/holoviews)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
1. Move `toctree` from `doc/index.rst` to a new file, `doc/_index.rst`
2. Move `doc/index.rst`'s content to `examples/index.ipynb` (and convert to markdown)
3. Include `index.ipynb` and `_index.rst` in `index.rst`
4. Commit `doc/index.rst` and `doc/_index.rst` and `examples/index.ipynb`.
5. When you run `nbsite_nbpagebuild.py ioam parambokeh ./examples ./doc` with current nbsite, it will overwrite `doc/index.rst`. Restore it from git, then continue with the rest of the doc build.