### PR TITLE
Force DateRange to use TextWidget as it is not a float-based Range

### DIFF
--- a/examples/apps/django2/manage.py
+++ b/examples/apps/django2/manage.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project.settings")
     try:
         from django.core.management import execute_from_command_line
-    except ImportError as exc:
+    except ImportError:
         raise ImportError(
             "Couldn't import Django. Are you sure it's installed and "
             "available on your PYTHONPATH environment variable? Did you "

--- a/parambokeh/widgets.py
+++ b/parambokeh/widgets.py
@@ -17,6 +17,8 @@ def TextWidget(*args, **kw):
     """Forces a parameter value to be text"""
     kw['value'] = str(kw['value'])
     kw.pop('options', None)
+    kw.pop('start', None)
+    kw.pop('end', None)
     return TextInput(*args,**kw)
 
 def StaticText(*args, **kw):
@@ -108,6 +110,7 @@ ptype2wtype = {
     param.Number:        FloatSlider,
     param.Integer:       IntSlider,
     param.Range:         RangeWidget,
+    param.DateRange:     TextWidget, # Workaround
     param.ListSelector:  MultiSelect,
     param.Action:        ButtonWidget,
     param.Date:          DateWidget,


### PR DESCRIPTION
Workaround for https://github.com/pyviz/EarthSim/issues/187 .  Doesn't actually provide an implementation for DateRange, but should avoid the current incorrect behavior.